### PR TITLE
feat(cache): add shared namespace handling for user access control

### DIFF
--- a/server/cache/user.js
+++ b/server/cache/user.js
@@ -8,6 +8,13 @@ const cache = {};
 
 const systemNamespaces = getSystemNamespaces()
 
+const SHARED_LABELS = ['bytetrade.io/ns-shared', 'app.bytetrade.io/app-shared'];
+
+const isShared = (item) => {
+	const labels = get(item, 'metadata.labels', {});
+	return SHARED_LABELS.some((label) => labels[label] === 'true');
+};
+
 const isAllowedMonitoringNamespace = (namespace, user) => {
 	if (!namespace || !user) {
 		return false;
@@ -111,9 +118,10 @@ function podListFormat(ctx, data) {
 		const systemTarget = systemNamespaces.find(
 			(system_namespace) => namespace === system_namespace
 		);
+		const sharedTarget = isShared(item);
 		return user.globalrole === ADMIN_ROLE
-			? userTarget || systemTarget
-			: userTarget;
+			? userTarget || systemTarget || sharedTarget
+			: userTarget || sharedTarget;
 	});
 	return {
 		...data,
@@ -134,9 +142,10 @@ function namespaceFormat(ctx, data) {
 		const systemTarget = systemNamespaces.find(
 			(system_namespace) => namespace === system_namespace
 		);
+		const sharedTarget = isShared(item);
 		return user.globalrole === ADMIN_ROLE
 			? true
-			: userTarget;
+			: userTarget || sharedTarget;
 	});
 	return {
 		...data,
@@ -202,6 +211,7 @@ module.exports = {
 	checkUrl,
 	isAdmin,
 	canModify,
+	isShared,
 	namespaceFormat,
 	mergeMonitoringNamespaceRequestParams,
 	patchMonitoringNamespacesPostBody

--- a/server/controllers/view.js
+++ b/server/controllers/view.js
@@ -35,6 +35,7 @@ const {
 	getUserInfo,
 	checkUrl,
 	isAdmin,
+	isShared,
 	namespaceFormat
 } = require('../cache/user.js');
 
@@ -222,7 +223,7 @@ function buildNamespaceGroupBuckets(items, usersData) {
 
 	for (const namespace of items) {
 		const name = namespace.metadata.name;
-		if (endsWith(name, 'shared')) {
+		if (isShared(namespace)) {
 			shared.push(namespace);
 			continue;
 		}


### PR DESCRIPTION
- Introduced `isShared` function to determine if a namespace is shared based on predefined labels.
- Updated namespace and pod list formatting functions to incorporate shared namespace checks for user permissions.
- Enhanced user access control by allowing shared namespaces to be recognized alongside user-specific and system namespaces.